### PR TITLE
Update dependencies to support Laravel 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
     "require": {
         "php": "^7.2|^8.0",
         "ext-zip": "*",
-        "illuminate/contracts": "^6.0|^7.0|^8.0",
-        "illuminate/support": "^6.0|^7.0|^8.0"
+        "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0",
+        "illuminate/support": "^6.0|^7.0|^8.0|^9.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^4.0|^5.0|^6.0",
+        "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0",
         "phpunit/phpunit": "^8.0|^9.0"
     },
     "autoload": {


### PR DESCRIPTION
The package wasn't installable on Laravel 9. I updated all Illuminate dependencies to support Laravel 9.