### PR TITLE
Update dependencies for laravel 10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ composer.lock
 docs
 vendor
 coverage
+.phpunit.cache
 .phpunit.result.cache
 .DS_Store

--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,14 @@
         }
     ],
     "require": {
-        "php": "^7.2|^8.0|^8.1",
+        "php": "^8.0",
         "ext-zip": "*",
-        "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0|^10.0",
-        "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0"
+        "illuminate/contracts": "^8.0|^9.0|^10.0",
+        "illuminate/support": "^8.0|^9.0|^10.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0",
-        "phpunit/phpunit": "^8.0|^9.0"
+        "orchestra/testbench": "^6.0|^7.0|^8.0",
+        "phpunit/phpunit": "^8.0|^9.0|^10.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
         }
     ],
     "require": {
-        "php": "^7.2|^8.0",
+        "php": "^7.2|^8.0|^8.1",
         "ext-zip": "*",
-        "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0",
-        "illuminate/support": "^6.0|^7.0|^8.0|^9.0"
+        "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0|^10.0",
+        "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0"
     },
     "require-dev": {
         "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <coverage>
     <include>
       <directory suffix=".php">src/</directory>
@@ -19,6 +19,6 @@
     <junit outputFile="build/report.junit.xml"/>
   </logging>
   <php>
-    <server name="XDEBUG_MODE" value="coverage" />
+    <server name="XDEBUG_MODE" value="coverage"/>
   </php>
 </phpunit>


### PR DESCRIPTION
This PR updates the dependencies that allow this library to work in Laravel 10. PHP8.1 was also added to the dependency since laravel 10 requires a minimum  PHP version of 8.1 